### PR TITLE
Add a lispy interface using conditions

### DIFF
--- a/mystic.asd
+++ b/mystic.asd
@@ -9,6 +9,8 @@
   :depends-on (:cl-mustache
                :split-sequence
                :anaphora
+               :alexandria
+               :ubiquitous
                :local-time)
   :components ((:module "src"
                 :serial t

--- a/src/mystic.lisp
+++ b/src/mystic.lisp
@@ -1,29 +1,29 @@
-(in-package :cl-user)
-(defpackage mystic
-  (:use :cl)
-  (:import-from :anaphora
-	        :aif
-                :it)
-  (:export :option
-           :option-title
-           :option-name
-           :option-docstring
-           :option-required-p
-           :option-default)
-  (:export :prompt-option
-           :multiple-choice-option
-           :boolean-option)
-  (:export :template
-           :template-name
-           :template-docstring
-           :template-options)
-  (:export :missing-required-option)
-  (:export :validate-options
-           :render-template
-           :render
-           :list-templates
-           :register-template))
-(in-package :mystic)
+(uiop:define-package #:mystic
+  (:use #:cl)
+  (:import-from #:anaphora
+                #:aif
+                #:it)
+  (:export #:option
+           #:option-title
+           #:option-name
+           #:option-docstring
+           #:option-required-p
+           #:option-default)
+  (:export #:prompt-option
+           #:multiple-choice-option
+           #:boolean-option
+           #:make-option)
+  (:export #:template
+           #:template-name
+           #:template-docstring
+           #:template-options)
+  (:export #:missing-required-option)
+  (:export #:validate-options
+           #:render-template
+           #:render
+           #:list-templates
+           #:register-template))
+(in-package #:mystic)
 
 ;;; Classes
 
@@ -52,7 +52,8 @@
               :documentation "A function used to process the value given to the option.")
    (default :reader option-default
             :initarg :default
-            :documentation "The option's default value."))
+            :initform nil
+            :documentation "The option's default value. This value will not be passed through an option processor."))
   (:documentation "An option to a template."))
 
 (defclass prompt-option (option)
@@ -87,6 +88,72 @@
 
 ;;; Errors
 
+(define-condition base-option-condition ()
+  ((option-name :reader option-name
+                :initarg :option-name
+                :type keyword
+                :documentation "The name of the option.")
+   (docstring :reader option-docstring
+              :initarg :docstring
+              :type string
+              :documentation "Documentation of the option.")))
+
+
+(define-condition ask-about-defaults (base-option-condition)
+  ((option-default :reader option-default
+                   :initarg :option-default
+                   :documentation "The default value of the option."))
+  (:report
+   (lambda (condition stream)
+     (format stream "Value for option '~A' was not supplied.~@
+                     ~@
+                     This option should be ~S~@
+                     ~@
+                     Do you want to enter the value or to use default: ~S?"
+             (option-name condition)
+             (option-docstring condition)
+             (option-default condition))))
+  (:documentation "Signalled when user passed REQUEST-ALL-OPTIONS-P argument to RENDER method and didn't supply some option value which has a default."))
+
+
+(define-condition ask-about-value-from-config (base-option-condition)
+  ((value :reader option-value
+          :initarg :value
+          :documentation "The value from config.")
+   (config-path :reader config-path
+                :initarg :config-path
+                :documentation "Path to the config."))
+  (:report
+   (lambda (condition stream)
+     (format stream "Value for option '~A' was not supplied, but was found in config:~@
+                     ~A~@
+                     ~@
+                     This option should be ~S~@
+                     ~@
+                     Do you want to enter another value or to use value from config: ~S?"
+             (option-name condition)
+             (config-path condition)
+             (option-docstring condition)
+             (option-value condition))))
+  (:documentation "Signalled when user passed REQUEST-ALL-OPTIONS-P argument to RENDER method, didn't supply some option value but a value for this option was found in a config file."))
+
+
+(define-condition ask-about-option-without-default (base-option-condition)
+  ((value :reader option-value
+          :initarg :value
+          :documentation "The value from config."))
+  (:report
+   (lambda (condition stream)
+     (format stream "Value for option '~A' was not supplied, and it has no default.~@
+                     ~@
+                     This option should be ~S~@
+                     ~@
+                     Do you want to enter another value or leave this option not filled?"
+             (option-name condition)
+             (option-docstring condition))))
+  (:documentation "Signalled when user passed REQUEST-ALL-OPTIONS-P argument to RENDER method, didn't supply an option value and we don't have a default or saved value for it."))
+
+
 (define-condition missing-required-option (simple-error)
   ((option-name :reader option-name
                 :initarg :option-name
@@ -94,31 +161,122 @@
                 :documentation "The name of the required option."))
   (:report
    (lambda (condition stream)
-     (format stream "The option '~A' was required but was not supplied."
-             (option-name condition))))
+     (format stream "The option '~A' is required but was not supplied.~@
+                     ~@
+                     This option should be ~S~@"
+             (option-name condition)
+             (option-docstring condition))))
   (:documentation "Signalled when a required option is not supplied."))
 
 ;;; Methods
 
-(defmethod validate-options ((template template) (options list))
-  "Take a plist of options, and validate it against the options in the template."
-  (let ((final-options (list)))
-    (loop for option in (template-options template) do
-      (aif (getf options (option-name option))
-           ;; Was the option supplied? If so, apply the option's processor to it
-           ;; and add it to the `final-options` list
-           (setf (getf final-options (option-name option))
-                 (funcall (option-processor option) it))
-           ;; Otherwise, check if it has a default value
-           (if (slot-boundp option 'default)
-               ;; Use this value
-               (setf (getf final-options (option-name option))
-                     (option-default option))
-               ;; No default? If the option is required, signal an error
-               (if (option-required-p option)
-                   (error 'missing-required-option
-                          :option-name (option-name option))))))
-    final-options))
+(defun read-new-value ()
+  (format *query-io* "~&Enter a new value: ")
+  (finish-output *query-io*)
+  (multiple-value-list (eval (read *query-io*))))
+
+
+(defun config-pathname ()
+  (ubiquitous:designator-pathname ubiquitous:*storage-pathname*
+                                  ubiquitous:*storage-type*))
+
+
+(defmethod validate-options ((template template) (options list) &key request-all-options-p)
+  "Take a plist of options, and validate it against the options in the template.
+
+   When ASK-ABOUT-DEFAULTS-P is T, Mystic will ask user about all options missing from OPTIONS list
+   but used in TEMPLATE. Asking is performed as condition signaling and a user can choose one of
+   available restarts:
+
+   - USE-DEFAULT - use default specified in the option's code.
+   - USE-VALUE-FROM-CONFIG - use value from config.
+   - USE-VALUE - enter a value interactively.
+   - STORE-VALUE - enter a value and store it in the config for future calls.
+"
+  (ubiquitous:with-local-storage ('options)
+    (loop with config-path = (config-pathname)
+          with all-options = (template-options template)
+          for option in all-options
+          for name = (option-name option)
+          for docstring = (option-docstring option)
+          for value = (getf options (option-name option))
+          for default = (option-default option)
+          for required = (option-required-p option)
+          for value-from-config = (ubiquitous:value name)
+          append (list name
+                       (restart-case
+                           (cond
+                             ;; Was the option supplied? If so, apply the option's processor to it
+                             ;; and add it to the `final-options` list
+                             (value
+                              (funcall (option-processor option)
+                                       value))
+                             (value-from-config
+                              (if request-all-options-p
+                                  (error 'ask-about-value-from-config
+                                         :option-name name
+                                         :docstring docstring
+                                         :value value-from-config
+                                         :config-path config-path)
+                                  value-from-config))
+                             ;; Otherwise, check if it has a default value?
+                             ;; Then use this value:
+                             (default (if request-all-options-p
+                                          (error 'ask-about-defaults
+                                                 :option-name name
+                                                 :docstring docstring
+                                                 :option-default default)
+                                          default))
+                             ;; No default? If the option is required, signal an error
+                             (required
+                              (error 'missing-required-option
+                                     :option-name name
+                                     :docstring docstring))
+                             ;; When option is not required and there is no default,
+                             ;; but user wants to decide about all options:
+                             (request-all-options-p
+                              (error 'ask-about-option-without-default
+                                     :option-name name
+                                     :docstring docstring)))
+                         (continue ()
+                           :report "Leave this option unfilled."
+                           :test (lambda (condition)
+                                   (declare (ignore condition))
+                                   ;; Required options always should be filled, because
+                                   ;; otherwise template might not render propertly.
+                                   ;; That is why we don't provide this restart for required options.
+                                   (unless required
+                                     t))
+                           nil)
+                         (use-default ()
+                           :report (lambda (stream)
+                                     (format stream "Use default value ~S."
+                                             default))
+                           :test (lambda (condition)
+                                   (declare (ignore condition))
+                                   (not (null default)))
+                           default)
+                         (use-value-from-config ()
+                           :report (lambda (stream)
+                                     (format stream "Use value from config ~S (~A)."
+                                             value-from-config
+                                             config-path))
+                           :test (lambda (condition)
+                                   (declare (ignore condition))
+                                   (not (null value-from-config)))
+                           value-from-config)
+                         (use-value (option-value)
+                           :report "Provide a value."
+                           :interactive read-new-value
+                           option-value)
+                         (store-value (option-value)
+                           :report (lambda (stream)
+                                     (format stream "Provide a value and save it for future renders to ~A."
+                                             config-path))
+                           :interactive read-new-value
+                           (setf (ubiquitous:value name)
+                                 option-value)
+                           option-value))))))
 
 (defgeneric render-template (template options directory)
   (:documentation "Render a @cl:param(template) to a @cl:param(directory). The
@@ -126,7 +284,7 @@
 
   (:method-combination progn))
 
-(defun render (template options directory)
+(defun render (template options directory &key request-all-options-p)
   "Render a @cl:param(template) to a @cl:param(directory). The
 @cl:param(options) are a plist of option names to their supplied values.
 
@@ -135,12 +293,14 @@ that needs to be done before handing over the task of rendering to the actual
 @c(render-template) method."
   (declare (type list options)
            (type pathname directory))
-  (let ((options (validate-options template options))
+  (let ((options (validate-options template options
+                                   :request-all-options-p request-all-options-p))
         (directory (uiop:ensure-directory-pathname directory)))
     (setf (getf options :year)
           (write-to-string (local-time:timestamp-year (local-time:now))))
     (ensure-directories-exist directory)
-    (render-template template options directory)))
+    (render-template template options directory)
+    (values)))
 
 (defvar *templates* (list)
   "The list of templates.")
@@ -156,3 +316,28 @@ that needs to be done before handing over the task of rendering to the actual
                                           (eq (class-name (class-of a))
                                               (class-name (class-of b)))))
   template)
+
+
+(defun make-option (name title docstring &key requiredp (processor #'identity) default)
+  (make-instance 'prompt-option
+                 :name name
+                 :title title
+                 :requiredp requiredp
+                 :docstring docstring
+                 :processor processor
+                 :default default))
+
+
+(defmethod print-object ((obj prompt-option) stream)
+  (print-unreadable-object (obj stream :type t)
+    (loop with first-item-p = t
+          for slot in '(name requiredp default docstring)
+          for value = (when (slot-boundp obj slot)
+                        (slot-value obj slot))
+          when value
+            do (if first-item-p
+                   (setf first-item-p nil)
+                   (write-char #\Space stream))
+               (format stream "~S ~A"
+                       (alexandria:make-keyword slot)
+                       value))))

--- a/src/mystic.lisp
+++ b/src/mystic.lisp
@@ -204,9 +204,9 @@
 
 
 (defgeneric validate-options (template options &key request-all-options-p)
-  (:documentation "Validates templates and returns a plist where keys are option names. This plist will be used to render templates."
+  (:documentation "Validates templates and returns a plist where keys are option names. This plist will be used to render templates.
 
-                  "A template or mixin might define a method for this generic function either to
+                   A template or mixin might define a method for this generic function either to
                    apply some additional validation or to add calculated variables to the plist. For example,
                    if some option contains a system name, you might want to uppercase it or to replace
                    dashes with underscores and store results to a separate variable."))

--- a/src/util.lisp
+++ b/src/util.lisp
@@ -1,29 +1,33 @@
-(in-package :cl-user)
-(defpackage mystic.util
-  (:use :cl)
-  (:export :read-template-file
-           :strip-whitespace
-           :parse-systems-list
-           :render-string
-           :write-file)
+(uiop:define-package #:mystic.util
+  (:use #:cl)
+  (:export #:read-template-file
+           #:strip-whitespace
+           #:parse-comma-separated-list
+           #:parse-systems-list
+           #:render-string
+           #:write-file)
   (:documentation "Utilities for Mystic."))
-(in-package :mystic.util)
+(in-package #:mystic.util)
 
-(defun read-template-file (pathname)
+(defun read-template-file (pathname &key (asdf-system :mystic))
   "Read a pathname relative to the templates/ directory into a string."
   (assert (uiop:relative-pathname-p pathname))
   (uiop:read-file-string
    (merge-pathnames pathname
-                    (asdf:system-relative-pathname :mystic #p"templates/"))))
+                    (asdf:system-relative-pathname asdf-system #p"templates/"))))
 
 (defun strip-whitespace (string)
   (string-trim '(#\Space #\Tab) string))
 
-(defun parse-systems-list (systems-list)
+(defun parse-comma-separated-list (systems-list)
   (loop for system-name
         in (split-sequence:split-sequence #\, systems-list)
         collecting
         (strip-whitespace system-name)))
+
+(defun parse-systems-list (systems-list)
+  ;; TODO: leaved for backward compatibility
+  (parse-comma-separated-list systems-list))
 
 (defun render-string (template-string data)
   "Render a Mustache template string to a string."

--- a/t/mystic.lisp
+++ b/t/mystic.lisp
@@ -1,10 +1,9 @@
-(in-package :cl-user)
-(defpackage mystic-test
-  (:use :cl :fiveam)
-  (:import-from :mystic
-                :validate-options)
-  (:export :run-tests))
-(in-package :mystic-test)
+(uiop:define-package #:mystic-test
+  (:use #:cl #:fiveam)
+  (:import-from #:mystic
+                #:validate-options)
+  (:export #:run-tests))
+(in-package #:mystic-test)
 
 (def-suite mystic
   :description "Mystic tests")
@@ -59,8 +58,8 @@
           (has str #p"my-project.asd"))
         (has "defsystem my-project-test" #p"my-project-test.asd")
         (has "# my-project" #p"README.md")
-        (has "defpackage my-project" #p"src/my-project.lisp")
-        (has "defpackage my-project-test" #p"t/my-project.lisp")))
+        (has "define-package #:my-project" #p"src/my-project.lisp")
+        (has "define-package #:my-project-test" #p"t/my-project.lisp")))
     (uiop:delete-directory-tree true-dir :validate t)))
 
 (defun run-tests ()

--- a/templates/library/library.lisp
+++ b/templates/library/library.lisp
@@ -1,16 +1,15 @@
-(in-package :cl-user)
-(defpackage mystic.template.library
-  (:use :cl)
-  (:import-from :mystic.util
-                :read-template-file
-                :parse-systems-list)
-  (:import-from :mystic
-                :prompt-option)
-  (:import-from :mystic.template.file
-                :file)
-  (:export :library-template)
+(uiop:define-package #:mystic.template.library
+  (:use #:cl)
+  (:import-from #:mystic.util
+                #:read-template-file
+                #:parse-comma-separated-list)
+  (:import-from #:mystic
+                #:make-option)
+  (:import-from #:mystic.template.file
+                #:make-file)
+  (:export #:library-template)
   (:documentation "A Mystic mixin to add a .travis.yml file."))
-(in-package :mystic.template.library)
+(in-package #:mystic.template.library)
 
 ;;; Classes
 
@@ -24,48 +23,41 @@
    :name "Library"
    :docstring "An empty Common Lisp library."
    :options
-   (list (make-instance 'prompt-option
-                        :name :name
-                        :title "Name"
-                        :requiredp t
-                        :docstring "The project's name.")
-         (make-instance 'prompt-option
-                        :name :author
-                        :title "Author"
-                        :requiredp t
-                        :docstring "The project author's name.")
-         (make-instance 'prompt-option
-                        :name :email
-                        :title "Email"
-                        :docstring "The project author's email.")
-         (make-instance 'prompt-option
-                        :name :homepage
-                        :title "Homepage"
-                        :docstring "The project's homepage.")
-         (make-instance 'prompt-option
-                        :name :license
-                        :title "License"
-                        :requiredp t
-                        :docstring "The project's license string, e.g. 'MIT', 'GPLv3'.")
-         (make-instance 'prompt-option
-                        :name :description
-                        :title "Description"
-                        :docstring "A short, one-line description of the project.")
-         (make-instance 'prompt-option
-                        :name :dependencies
-                        :title "Dependencies"
-                        :processor (lambda (deps)
-                                     (format nil "~{:~A~^~%               ~}"
-                                             (parse-systems-list deps)))
-                        :docstring "The project's dependent systems, as a comma-separated list, e.g: 'local-time, lucerne, crane'."))
+   (list (make-option :name
+                      "Name"
+                      "The project's name."
+                      :requiredp t)
+         (make-option :author
+                      "Author"
+                      "The project author's name."
+                      :requiredp t)
+         (make-option :email
+                      "Email"
+                      "The project author's email.")
+         (make-option :homepage
+                      "Homepage"
+                      "The project's homepage.")
+         (make-option :license
+                      "License"
+                      "The project's license string, e.g. 'MIT', 'GPLv3'."
+                      :requiredp t)
+         (make-option :description
+                      "Description"
+                      "A short, one-line description of the project.")
+         (make-option :dependencies
+                      "Dependencies"
+                      "The project's dependent systems, as a comma-separated list, e.g: 'local-time, lucerne, crane'."
+                      :processor (lambda (deps)
+                                   (format nil "~{:~A~^~%               ~}"
+                                           (parse-comma-separated-list deps)))))
    :files
    (list
-    (make-instance 'file
-                   :path "{{name}}.asd"
-                   :content (read-template-file #p"library/asdf.lisp"))
-    (make-instance 'file
-                   :path "src/{{name}}.lisp"
-                   :content (read-template-file #p"library/source.lisp"))))
-  (:documentation "A Mystic mixin to add a .travis.yml file."))
+    (make-file :mystic
+               "library/asdf.lisp"
+               "{{name}}.asd")
+    (make-file :mystic
+               "library/source.lisp"
+               "src/{{name}}.lisp")))
+  (:documentation "A Mystic class to create empty Common Lisp library."))
 
 (mystic:register-template (make-instance 'library-template))

--- a/templates/library/source.lisp
+++ b/templates/library/source.lisp
@@ -1,4 +1,3 @@
-(in-package :cl-user)
-(defpackage {{name}}
-  (:use :cl))
-(in-package :{{name}})
+(uiop:define-package #:{{name}}
+  (:use #:cl))
+(in-package #:{{name}})

--- a/templates/mixins/file/file.lisp
+++ b/templates/mixins/file/file.lisp
@@ -1,16 +1,17 @@
-(in-package :cl-user)
-(defpackage mystic.template.file
-  (:use :cl)
-  (:import-from :mystic.util
-                :render-string
-                :write-file)
-  (:export :file
-           :file-path
-           :file-content
-           :file-mixin)
-  (:documentation "A Mystic template mixin for rendering a list of files using
- Mustache."))
-(in-package :mystic.template.file)
+(uiop:define-package #:mystic.template.file
+  (:use #:cl)
+  (:import-from #:mystic.util
+                #:render-string
+                #:write-file)
+  (:import-from #:mystic.util
+                #:read-template-file)
+  (:export #:file
+           #:file-path
+           #:file-content
+           #:file-mixin
+           #:make-file)
+  (:documentation "A Mystic template mixin for rendering a list of files using Mustache."))
+(in-package #:mystic.template.file)
 
 ;;; Classes
 
@@ -44,3 +45,8 @@ a Mustache template string.")
                                             directory))
            (content (mystic.util:render-string (file-content file) options)))
       (write-file content full-file-path))))
+
+(defun make-file (system-name path output-path-template)
+  (make-instance 'file
+                 :path output-path-template
+                 :content (read-template-file path :asdf-system system-name)))

--- a/templates/mixins/fiveam/code.lisp
+++ b/templates/mixins/fiveam/code.lisp
@@ -1,8 +1,7 @@
-(in-package :cl-user)
-(defpackage {{name}}-test
-  (:use :cl :fiveam)
-  (:export :run-tests))
-(in-package :{{name}}-test)
+(uiop:define-package #:{{name}}-test
+  (:use #:cl #:fiveam)
+  (:export #:run-tests))
+(in-package #:{{name}}-test)
 
 (def-suite tests
   :description "{{name}} tests.")

--- a/templates/mixins/fiveam/fiveam.lisp
+++ b/templates/mixins/fiveam/fiveam.lisp
@@ -1,13 +1,12 @@
-(in-package :cl-user)
-(defpackage mystic.template.fiveam
-  (:use :cl)
-  (:import-from :mystic.util
-                :read-template-file
-                :render-string
-                :write-file)
-  (:export :fiveam-mixin)
+(uiop:define-package #:mystic.template.fiveam
+  (:use #:cl)
+  (:import-from #:mystic.util
+                #:read-template-file
+                #:render-string
+                #:write-file)
+  (:export #:fiveam-mixin)
   (:documentation "A Mystic mixin to add a FiveAM test system and test suite."))
-(in-package :mystic.template.fiveam)
+(in-package #:mystic.template.fiveam)
 
 ;;; Classes
 

--- a/templates/mixins/gitignore/gitignore.lisp
+++ b/templates/mixins/gitignore/gitignore.lisp
@@ -1,13 +1,12 @@
-(in-package :cl-user)
-(defpackage mystic.template.gitignore
-  (:use :cl)
-  (:import-from :mystic.util
-                :read-template-file
-                :render-string
-                :write-file)
-  (:export :gitignore-mixin)
+(uiop:define-package #:mystic.template.gitignore
+  (:use #:cl)
+  (:import-from #:mystic.util
+                #:read-template-file
+                #:render-string
+                #:write-file)
+  (:export #:gitignore-mixin)
   (:documentation "A Mystic mixin to add a .gitignore file to a project."))
-(in-package :mystic.template.gitignore)
+(in-package #:mystic.template.gitignore)
 
 ;;; Classes
 

--- a/templates/mixins/readme/readme.lisp
+++ b/templates/mixins/readme/readme.lisp
@@ -1,13 +1,12 @@
-(in-package :cl-user)
-(defpackage mystic.template.readme
-  (:use :cl)
-  (:import-from :mystic.util
-                :read-template-file
-                :render-string
-                :write-file)
-  (:export :readme-mixin)
+(uiop:define-package #:mystic.template.readme
+  (:use #:cl)
+  (:import-from #:mystic.util
+                #:read-template-file
+                #:render-string
+                #:write-file)
+  (:export #:readme-mixin)
   (:documentation "A Mystic mixin to add a README.md file."))
-(in-package :mystic.template.readme)
+(in-package #:mystic.template.readme)
 
 ;;; Classes
 

--- a/templates/mixins/travis/travis.lisp
+++ b/templates/mixins/travis/travis.lisp
@@ -1,13 +1,12 @@
-(in-package :cl-user)
-(defpackage mystic.template.travis
-  (:use :cl)
-  (:import-from :mystic.util
-                :read-template-file
-                :render-string
-                :write-file)
-  (:export :travis-mixin)
+(uiop:define-package #:mystic.template.travis
+  (:use #:cl)
+  (:import-from #:mystic.util
+                #:read-template-file
+                #:render-string
+                #:write-file)
+  (:export #:travis-mixin)
   (:documentation "A Mystic mixin to add a .travis.yml file to a project."))
-(in-package :mystic.template.travis)
+(in-package #:mystic.template.travis)
 
 ;;; Classes
 


### PR DESCRIPTION
This commit adds ability to ask user to enter missing options by choosing a restart in the interactive lisp debugger. Now Mystic provides a multiple restarts:

- USE-DEFAULT - use default specified in the option's code.
- USE-VALUE-FROM-CONFIG - use value from config.
- USE-VALUE - enter a value interactively.
- STORE-VALUE - enter a value and store it in the config for future calls.

Some of them available only in particular circumstances.

Also argument REQUEST-ALL-OPTIONS-P was added to the MYSTIC:RENDER function. When this argument is T, Mystic will ask about each option except provided explicitly to RENDER function.

Here is how it looks like in the SLY debugger:

```lisp
Value for option 'AUTHOR' was not supplied, but was found in config:
/Users/art/.config/common-lisp/ubiquitous/mystic/options.conf.lisp

This option should be "The project author's name."

Do you want to enter another value or to use value from config: "Alexander Artemenko"?
   [Condition of type MYSTIC::ASK-ABOUT-VALUE-FROM-CONFIG]

Restarts:
 0: [USE-VALUE-FROM-CONFIG] Use value from config "Alexander Artemenko" (/Users/art/.config/common-lisp/ubiquitous/mystic/options.conf.lisp).
 1: [USE-VALUE] Provide a value.
 2: [STORE-VALUE] Provide a value and save it for future renders to /Users/art/.config/common-lisp/ubiquitous/mystic/options.conf.lisp.
 3: [RETRY] Retry SLY mREPL evaluation request.
 4: [*ABORT] Return to SLY's top level.
 5: [ABORT] Quit process.
```

Pay attention to the first three restarts. First one suggest to use value found in the config file (did I mention this commit also makes Mystic support config files?). Second restart will request a new value for an option. Third one is like the second, but entered value will be saved to the config for future uses.

So, REQUEST-ALL-OPTIONS-P option allows user to disover all options used in the template and I recommend to set it to T. When this option is NIL, Mystic will ask only about missing "required" options and silently load options available from the configuration file.

Function MAKE-OPTION was added, to make explicit which option slots are required. Also, READ-TEMPLATE-FILE function now allows to specify an ASDF system to search template in. This makes it reusable.

Function MAKE-FILE was added to simplify a way how the template file is created. Now you just need to specify an ASDF system and two filenames like this:

```lisp
(make-file :mystic
           "library/asdf.lisp"
           "{{name}}.asd")
```

Package definitions were modernized, to use non-interned symbols and UIOP:DEFINE-PACKAGE (it does not output error on package redefinition under the LispWorks).